### PR TITLE
Bugfix for multidisk error

### DIFF
--- a/Linux/psxtract.c
+++ b/Linux/psxtract.c
@@ -224,7 +224,12 @@ int decrypt_iso_header(FILE *psar, int header_offset, int header_size, unsigned 
 	int pgd_size = decrypt_pgd(iso_header, header_size, 2, pgd_key);
 
 	if (pgd_size > 0)
-		printf("ISO header successfully decrypted! Saving as ISO_HEADER.BIN...\n\n");
+	{
+	    if (disc_num > 0)
+		    printf("ISO header successfully decrypted! Saving as ISO_HEADER_%d.BIN...\n\n", disc_num);
+	    else
+		    printf("ISO header successfully decrypted! Saving as ISO_HEADER.BIN...\n\n");
+	}
 	else
 	{
 		printf("ERROR: ISO header decryption failed!\n\n");
@@ -686,7 +691,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_1.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");
@@ -721,7 +726,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_2.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");
@@ -756,7 +761,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_3.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");
@@ -791,7 +796,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_4.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");
@@ -826,7 +831,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_5.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");

--- a/Windows/src/psxtract.cpp
+++ b/Windows/src/psxtract.cpp
@@ -224,7 +224,12 @@ int decrypt_iso_header(FILE *psar, int header_offset, int header_size, unsigned 
 	int pgd_size = decrypt_pgd(iso_header, header_size, 2, pgd_key);
 
 	if (pgd_size > 0)
-		printf("ISO header successfully decrypted! Saving as ISO_HEADER.BIN...\n\n");
+	{
+	    if (disc_num > 0)
+		    printf("ISO header successfully decrypted! Saving as ISO_HEADER_%d.BIN...\n\n", disc_num);
+	    else
+		    printf("ISO header successfully decrypted! Saving as ISO_HEADER.BIN...\n\n");
+	}
 	else
 	{
 		printf("ERROR: ISO header decryption failed!\n\n");
@@ -686,7 +691,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_1.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");
@@ -721,7 +726,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_2.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");
@@ -756,7 +761,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_3.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");
@@ -791,7 +796,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_4.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");
@@ -826,7 +831,7 @@ int decrypt_multi_disc(FILE *psar, int psar_size, int startdat_offset, unsigned 
 			printf("Aborting...\n");
 
 		// Re-open in read mode (just to be safe).
-		FILE* iso_table = fopen("ISO_HEADER.BIN", "rb");
+		FILE* iso_table = fopen("ISO_HEADER_5.BIN", "rb");
 		if (iso_table == NULL)
 		{
 			printf("ERROR: No decrypted ISO header found!\n");


### PR DESCRIPTION
Hey, really impressive work on this project! Unfortunately, commit 04433c17 screws up the ability to create ISOs for games that require multiple disks. Prior to this, you would go disk by disk, and dump header information into a file named ISO_HEADER.BIN, which would get overwritten each time. You changed this to create a unique header file for each disk, with the name ISO_HEADER_#.BIN (where # is the disk number). I believe your intent in changing that behavior was to leave behind all the data for analysis (as discussed in https://github.com/Hykem/psxtract/issues/2), but a bug is introduced since the decrypt_multi_disc function still checks for the ISO_HEADER.BIN file, which now doesn't exist.

Hopefully this patch resolves the issue :) I tested it on the pbp file for Metal Gear Solid, and it appeared to work. However, I am unable to prove it for certain, since I don't have access to a legal copy of the PSX bios.